### PR TITLE
libhardware: Add back a missed commit

### DIFF
--- a/include/hardware/audio_amplifier.h
+++ b/include/hardware/audio_amplifier.h
@@ -132,6 +132,11 @@ typedef struct amplifier_device {
      */
     int (*set_feedback)(struct amplifier_device *device,
         void *adev, uint32_t devices, bool enable);
+
+    /**
+     * Amplifier calibration
+     */
+    int (*calibrate)(void *adev);
 } amplifier_device_t;
 
 typedef struct amplifier_module {


### PR DESCRIPTION
hardware/qcom-caf/sm8250/audio/hal/audio_extn/audio_amplifier.c:53:17: error: no member named 'calibrate' in 'struct amplifier_device'
    if (amp.hw->calibrate) {
        ~~~~~~  ^
hardware/qcom-caf/sm8250/audio/hal/audio_extn/audio_amplifier.c:54:22: error: no member named 'calibrate' in 'struct amplifier_device'
        rc = amp.hw->calibrate(adev);
             ~~~~~~  ^
